### PR TITLE
Become Carthage compatible

### DIFF
--- a/SwiftlineTests/Swiftline.xcodeproj/project.pbxproj
+++ b/SwiftlineTests/Swiftline.xcodeproj/project.pbxproj
@@ -503,6 +503,7 @@
 		D72766181BF416AC00126D99 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -512,6 +513,7 @@
 				INFOPLIST_FILE = Swiftline/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = nsomar.Swiftline;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -521,6 +523,7 @@
 		D72766191BF416AC00126D99 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -530,6 +533,7 @@
 				INFOPLIST_FILE = Swiftline/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = nsomar.Swiftline;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
Fixes:
- Changed the code sign identity from "-" to "don't code sign"
- Lowered deployment target from 10.11 to 10.9 (shouldn't break anything)

This passes `carthage build --no-skip-current` for me. :)
