### PR TITLE
`ask` now infers the type

### DIFF
--- a/Pod/Swiftline/Ask/Ask.swift
+++ b/Pod/Swiftline/Ask/Ask.swift
@@ -10,41 +10,25 @@ import Foundation
 
 
 /**
- Display a promt to the user
+ Display a prompt to the user
  
- - parameter prompt:   The message to display
- - parameter customizationBlock: The block to costumize the prompt before displaying
- 
- - returns: The string enters from the user
- */
-public func ask(prompt: String, customizationBlock: (AskSettings<String> -> Void)? = nil) -> String {
-    return ask(prompt, type: String.self, customizationBlock: customizationBlock)
-}
-
-
-/**
-  Display a promt to the user
-
  - parameter prompt:The message to display
- - parameter type: The value type to be expected from the user
  - parameter customizationBlock: The block to costumize the prompt before displaying
  
- - returns: The string casted to the type requested
+ - returns: The string casted to the type inferred
  - discussion: If the user enters a wrong type, ask will keep prompting until a correct value has been entered
  */
-public func ask<T: ArgConvertibleType>(prompt: String, type: T.Type, customizationBlock: (AskSettings<T> -> Void)? = nil) -> T {
-    
+public func ask<T: ArgConvertibleType>(prompt: String, customizationBlock: (AskSettings<T> -> Void)? = nil) -> T {
     PromptSettings.print(prompt)
-    
+  
     let settings = getSettings(customizationBlock)
-    
+  
     if settings.confirm {
         return getValidatedStringWithConfirmation(settings)
     } else {
         return getValidatedString(settings)
     }
 }
-
 
 // MARK:- Internal functions
 

--- a/SwiftlineTests/SwiftlineTests/AskTests.swift
+++ b/SwiftlineTests/SwiftlineTests/AskTests.swift
@@ -16,7 +16,7 @@ class AskerTest: QuickSpec {
         
         it("reads a string from the stdin") {
             PromptSettings.reader = DummyPromptReader(toReturn: "A String")
-            let res = ask("Enter a string")
+            let res: String = ask("Enter a string")
             
             expect(res).to(equal("A String"))
             expect(promptPrinter.printed).to(equal("Enter a string\n"))
@@ -24,7 +24,7 @@ class AskerTest: QuickSpec {
         
         it("reads an Int from the stdin") {
             PromptSettings.reader = DummyPromptReader(toReturn: "1")
-            let res = ask("Enter a string", type: Int.self)
+            let res: Int = ask("Enter a string")
             
             expect(res).to(equal(1))
             expect(promptPrinter.printed).to(equal("Enter a string\n"))
@@ -33,7 +33,7 @@ class AskerTest: QuickSpec {
         it("keeps asking if entered is not an int") {
             PromptSettings.reader = DummyPromptReader(toReturn: "x", "y", "1")
             
-            let res = ask("Enter a string", type: Int.self)
+            let res: Int = ask("Enter a string")
             
             let prompt = ["Enter a string",
                 "You must enter a valid Integer.",
@@ -46,8 +46,8 @@ class AskerTest: QuickSpec {
         
         it("reads an double from the stdin") {
             PromptSettings.reader = DummyPromptReader(toReturn: "1")
-            let res = ask("Enter a string", type: Double.self)
-            
+            let res: Double = ask("Enter a string")
+          
             expect(res).to(equal(1.0))
             expect(promptPrinter.printed).to(equal("Enter a string\n"))
         }
@@ -69,7 +69,7 @@ class AskerTest: QuickSpec {
         
         it("ask for confirmation") {
             PromptSettings.reader = DummyPromptReader(toReturn: "val", "Y")
-            let res = ask("Enter a string") { $0.confirm = true }
+            let res: String = ask("Enter a string") { $0.confirm = true }
             
             expect(res).to(equal("val"))
             expect(promptPrinter.printed).to(equal("Enter a string\nAre you sure?  "))
@@ -77,7 +77,7 @@ class AskerTest: QuickSpec {
         
         it("ask for confirmation, if no is passed it keeps asking") {
             PromptSettings.reader = DummyPromptReader(toReturn: "val", "N", "other val", "y")
-            let res = ask("Enter a string") { $0.confirm = true }
+            let res: String = ask("Enter a string") { $0.confirm = true }
             
             expect(res).to(equal("other val"))
             
@@ -91,7 +91,7 @@ class AskerTest: QuickSpec {
             
             PromptSettings.reader = DummyPromptReader(toReturn: "1", "n", "10", "9", "yes")
             
-            let res = ask("Age?", type: Int.self) {
+            let res: Int = ask("Age?") {
                 $0.confirm = true
                 $0.addInvalidCase("Age not correct") { $0 == 10 }
             }


### PR DESCRIPTION
Not sure if this is something you would be interested in, but I collapsed the 2 versions of `ask` into one that infers the type so you don't need to explicitly specify it (that didn't look so Swifty to me).

So:

``` diff
- let myInt = ask("How old are you?", type: Int.self)
+ let myInt: Int = ask("How old are you?")
```

The only downside is that now there is no default return type anymore (before it was `String`). I don't see it necessarily as a downside but this is your call :)

I also updated the tests, they're still passing.
Let me know if you like it or you find it confusing.

If you find it a good improvement, I will also edit the README.md and commit it in this same PR.
