### PR TITLE
don't return the command name in list of arguments

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -266,6 +266,8 @@ Returns the arguments passed to the script. For example when calling `script -f1
 
 `Args.parsed.flags` returns a dictinary of flags `["f1": "val1", "f2", "val2"]`
 
+`Args.parsed.command` returns the name of the executable itself `"script"`
+
 ## Installation
 You can install Swiftline using CocoaPods, carthage and Swift package manager
 

--- a/Source/Args.swift
+++ b/Source/Args.swift
@@ -27,20 +27,32 @@ public class Args {
       return result
     }
     
-    var result = [String: String]()
-    let parsedArges = ArgsParser.parseFlags(all)
+    var parsedFlags = [String: String]()
+    let parsedArgs = ArgsParser.parseFlags(all)
     
-    parsedArges.0.forEach {
-      result[$0.argument.name] = $0.value ?? ""
+    parsedArgs.0.forEach {
+      parsedFlags[$0.argument.name] = $0.value ?? ""
     }
-    
-    cachedResults = ParsedArgs(flags: result, parameters: parsedArges.1)
+
+    var arguments = parsedArgs.1
+
+    // the first argument is always the executable's name
+    var commandName = ""
+    if let firstArgument = arguments.first { // just in case!
+        commandName = firstArgument
+        arguments.removeFirst(1)
+    }
+
+    cachedResults = ParsedArgs(command: commandName, flags: parsedFlags, parameters: arguments)
     return cachedResults!
   }
 }
 
 
 public struct ParsedArgs {
+  /// The name of the executable that was invoked from the command line
+  public let command: String
+
   /// Parsed flags will be prepred in a dictionary, the key is the flag and the value is the flag value
   public let flags: [String: String]
   

--- a/SwiftlineTests/SwiftlineTests/ArgsTests.swift
+++ b/SwiftlineTests/SwiftlineTests/ArgsTests.swift
@@ -18,7 +18,7 @@ class ArgsTests: QuickSpec {
       }
       
       it("creats a hash from passed args") {
-        ProcessInfo.internalProcessInfo = DummyProcessInfo("-f", "file.rb", "--integer", "1", "Some custom one", "one", "two", "--no-ff")
+        ProcessInfo.internalProcessInfo = DummyProcessInfo("excutable_name", "-f", "file.rb", "--integer", "1", "Some custom one", "one", "two", "--no-ff")
         let result = [
           "f": "file.rb",
           "integer": "1",
@@ -26,6 +26,7 @@ class ArgsTests: QuickSpec {
         
         expect(Args.parsed.flags).to(equal(result))
         expect(Args.parsed.parameters).to(equal(["Some custom one", "one", "two"]))
+        expect(Args.parsed.command).to(equal("excutable_name"))
       }
     }
     


### PR DESCRIPTION
This makes the behavior line up with description in the README
- Make new property on Args to get the command name
- Also fixes a typo, and makes some names better
