### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -269,14 +269,14 @@ Returns the arguments passed to the script. For example when calling `script -f1
 ## Installation
 You can install Swiftline using cocoapods,
 
-### Cocoapods
+### CocoaPods
     use_frameworks!
     pod 'Swiftline'
 
 ### Carthage
     github 'swiftline/swiftline'
 
-### Cocoapods + Rome plugin
+### CocoaPods + Rome plugin
 If you want to use swiftline in a script you can use [Rome](https://github.com/neonichu/Rome) cocoapod plugin. This plugin builds the framework from the pod file and place them in a Rome directory.
 
     platform :osx, '10.10'

--- a/Readme.md
+++ b/Readme.md
@@ -2,30 +2,30 @@
 <img src="http://swiftline.github.io/img/intro-bg.svg" width="400" align="middle"/>
 <br/>
 </p>
-[![Build Status](https://travis-ci.org/Swiftline/Swiftline.svg?branch=master)](https://travis-ci.org/Swiftline/Swiftline) 
-[![Platform](https://img.shields.io/badge/platform-osx-lightgrey.svg)](https://travis-ci.org/Swiftline/Swiftline) 
-[![Language: Swift](https://img.shields.io/badge/language-swift-orange.svg)](https://travis-ci.org/Swiftline/Swiftline) 
-[![CocoaPods](https://img.shields.io/cocoapods/v/Swiftline.svg)](https://cocoapods.org/pods/Swiftline) 
-[![Carthage](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) 
-[![GITTER: join chat](https://img.shields.io/badge/GITTER-join%20chat-00D06F.svg)](https://gitter.im/Swiftline?utm_source=share-link&utm_medium=link&utm_campaign=share-link) 
-[![GITTER: join chat](https://img.shields.io/badge/license-MIT-000000.svg)](https://github.com/Swiftline/Swiftline/blob/oarrabi/adding-env-and-args/LICENCE) 
-<br/>  
-Swiftline is a set of tools to help you create command line applications. Swiftline is inspired by [highline](https://github.com/JEG2/highline)   
+[![Build Status](https://travis-ci.org/Swiftline/Swiftline.svg?branch=master)](https://travis-ci.org/Swiftline/Swiftline)
+[![Platform](https://img.shields.io/badge/platform-osx-lightgrey.svg)](https://travis-ci.org/Swiftline/Swiftline)
+[![Language: Swift](https://img.shields.io/badge/language-swift-orange.svg)](https://travis-ci.org/Swiftline/Swiftline)
+[![CocoaPods](https://img.shields.io/cocoapods/v/Swiftline.svg)](https://cocoapods.org/pods/Swiftline)
+[![Carthage](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+[![GITTER: join chat](https://img.shields.io/badge/GITTER-join%20chat-00D06F.svg)](https://gitter.im/Swiftline?utm_source=share-link&utm_medium=link&utm_campaign=share-link)
+[![GITTER: join chat](https://img.shields.io/badge/license-MIT-000000.svg)](https://github.com/Swiftline/Swiftline/blob/oarrabi/adding-env-and-args/LICENCE)
+<br/>
+Swiftline is a set of tools to help you create command line applications. Swiftline is inspired by [highline](https://github.com/JEG2/highline)
 <br/>
 Swiftline contains the following:
 
 - Colorize: Helps adding colors to strings written to the terminal
 - Ask , Choose  and agree: Easily create prompt for asking the user more info
-- Run: A quick way to run an external command and read its standard output and standard error. 
+- Run: A quick way to run an external command and read its standard output and standard error.
 - Env: Read and write environment variables [ruby-flavored](http://ruby-doc.org/core-2.2.0/ENV.html)
 - Args: Parses command line arguments and return a hash of the passed flags
 
 ## Contents
-[Usage](#usage)   
-[Installation](#installation)   
-[Examples](#examples)   
-[Docs](http://swiftline.github.io/docs/index.html)   
-[Tests](#tests)   
+[Usage](#usage)
+[Installation](#installation)
+[Examples](#examples)
+[Docs](http://swiftline.github.io/docs/index.html)
+[Tests](#tests)
 
 ## Usage
 
@@ -75,7 +75,7 @@ Ask can be used to ask for value of Int, Double or Float types, to ask for an in
     let age = ask("How old are you?", type: Int.self)
 ```
 If the user prints something thats not convertible to integer, a new prompt is displayed to him, this prompt will keep displaying until the user enters an Int:
-    
+
     How old are you?
     None
     You must enter a valid Integer.
@@ -138,7 +138,7 @@ This will print:
     Whats your favorite programming language?
 
 The user can either choose the numbers (1..5) or the item itself. If the user enters a wrong input. A prompt will keep showing until the user makes a correct choice
-    
+
     Whats your favorite programming language? JavaScript
     You must choose one of [1, 2, 3, 4, 5, Swift, Objective C, Ruby, Python, Java :S].
     ?  BBB
@@ -161,11 +161,11 @@ The number on the left can be changed to letters, here is how you could do that:
 ```siwft
     let choice = choose("Whats your favorite programming language? ", type: String.self) { settings in
         //choice value will be set to GOOD
-        settings.addChoice("Swift") { "GOOD" } 
+        settings.addChoice("Swift") { "GOOD" }
 
         //choice value will be set to BAD
         settings.addChoice("Java") { "BAD" }
-        
+
         settings.index = .Letters
         settings.indexSuffix = " ----> "
     }
@@ -191,7 +191,7 @@ If the user enters any invalid input, agree will keep prompting him for a Yes/No
     Are you sure you want to `rm -rf /` ?  Wait
     Please enter "yes" or "no".
     Are you sure you want to `rm -rf /` ?  No
-    
+
     You entered false
 
 ## Run 🏃
@@ -232,9 +232,9 @@ To customize the run function, you can pass in a customization block:
     - `EchoSettings.Stdout`: The stdout returned from running the command will be printed to the terminal
     - `EchoSettings.Stderr`: The stderr returned from running the command will be printed to the terminal
     - `EchoSettings.Command`: The command executed will be printed to the terminal
-- `settings.interactive`: defaults to false. If set to true the command will be executed using `system` kernel function and only the exit status will be captured. If set to false, the command will be executed using `NSTask` and both stdout and stderr will be captured. 
-Set `interactive` to true if you expect the launched command to ask input from the user through the stdin. 
-    
+- `settings.interactive`: defaults to false. If set to true the command will be executed using `system` kernel function and only the exit status will be captured. If set to false, the command will be executed using `NSTask` and both stdout and stderr will be captured.
+Set `interactive` to true if you expect the launched command to ask input from the user through the stdin.
+
 `runWithoutCapture("command")` is a quick way to run a command in interactive mode. The return value is the exit code of that command.
 
 ## Env
@@ -259,32 +259,45 @@ Returns the arguments passed to the script. For example when calling `script -f1
 
 `Args.all ` returns an array of all the raw arguments, in this example it will be `["-f1", "val1", "-f2", "val2", "--", "val3", "val4"`
 
-`Args.parsed ` returns a structure that contains a parsed map of arguments and an array of arguments, for this example:    
+`Args.parsed ` returns a structure that contains a parsed map of arguments and an array of arguments, for this example:
 
 
-`Args.parsed.parameters` returns `["val3", "val4"]`    
+`Args.parsed.parameters` returns `["val3", "val4"]`
 
 `Args.parsed.flags` returns a dictinary of flags `["f1": "val1", "f2", "val2"]`
 
 ## Installation
-You can install Swiftline using cocoapods,
+You can install Swiftline using CocoaPods, carthage and Swift package manager
 
-### CocoaPods
+### Cocoapods
     use_frameworks!
     pod 'Swiftline'
 
 ### Carthage
     github 'swiftline/swiftline'
 
+### Swift Package Manager
+Add swiftline as dependency in your `Package.swift`
+
+```
+  import PackageDescription
+
+  let package = Package(name: "YourPackage",
+    dependencies: [
+      .Package(url: "https://github.com/Swiftline/Swiftline.git", majorVersion: 0, minor: 3),
+    ]
+  )
+```
+
 ### CocoaPods + Rome plugin
-If you want to use swiftline in a script you can use [Rome](https://github.com/neonichu/Rome) cocoapod plugin. This plugin builds the framework from the pod file and place them in a Rome directory.
+If you want to use swiftline in a script you can use [Rome](https://github.com/neonichu/Rome) CocoaPods plugin. This plugin builds the framework from the pod file and place them in a Rome directory.
 
     platform :osx, '10.10'
     plugin 'cocoapods-rome'
 
     pod 'Swiftline'
 
-### Manual 
+### Manual
 To install Swiftline manually, add `Pod/Swiftline` directory to your project.
 
 ## Examples
@@ -304,5 +317,5 @@ Documentation can be found [here](http://swiftline.github.io/docs/index.html)
 - Better documentation
 
 ## Credits
-Daniel Beere for creating the logo [@DanielBeere](https://twitter.com/DanielBeere) check out [danielbeere on dribble](https://dribbble.com/danielbeere)    
+Daniel Beere for creating the logo [@DanielBeere](https://twitter.com/DanielBeere) check out [danielbeere on dribble](https://dribbble.com/danielbeere)
 Omar Abdelhafith current project maintainer [@ifnottrue](https://twitter.com/ifnottrue)


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
