### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -267,7 +267,7 @@ Returns the arguments passed to the script. For example when calling `script -f1
 `Args.parsed.flags` returns a dictinary of flags `["f1": "val1", "f2", "val2"]`
 
 ## Installation
-You can install Swiftline using cocoapods, carthage and Swift package manager
+You can install Swiftline using CocoaPods, carthage and Swift package manager
 
 ### CocoaPods
     use_frameworks!
@@ -290,7 +290,7 @@ Add swiftline as dependency in your `Package.swift`
 ```
 
 ### CocoaPods + Rome plugin
-If you want to use swiftline in a script you can use [Rome](https://github.com/neonichu/Rome) cocoapod plugin. This plugin builds the framework from the pod file and place them in a Rome directory.
+If you want to use swiftline in a script you can use [Rome](https://github.com/neonichu/Rome) CocoaPods plugin. This plugin builds the framework from the pod file and place them in a Rome directory.
 
     platform :osx, '10.10'
     plugin 'cocoapods-rome'

--- a/Readme.md
+++ b/Readme.md
@@ -267,7 +267,7 @@ Returns the arguments passed to the script. For example when calling `script -f1
 `Args.parsed.flags` returns a dictinary of flags `["f1": "val1", "f2", "val2"]`
 
 ## Installation
-You can install Swiftline using CocoaPods, carthage and Swift package manager
+You can install Swiftline using cocoapods, carthage and Swift package manager
 
 ### CocoaPods
     use_frameworks!
@@ -290,7 +290,7 @@ Add swiftline as dependency in your `Package.swift`
 ```
 
 ### CocoaPods + Rome plugin
-If you want to use swiftline in a script you can use [Rome](https://github.com/neonichu/Rome) CocoaPods plugin. This plugin builds the framework from the pod file and place them in a Rome directory.
+If you want to use swiftline in a script you can use [Rome](https://github.com/neonichu/Rome) cocoapod plugin. This plugin builds the framework from the pod file and place them in a Rome directory.
 
     platform :osx, '10.10'
     plugin 'cocoapods-rome'

--- a/Readme.md
+++ b/Readme.md
@@ -269,7 +269,7 @@ Returns the arguments passed to the script. For example when calling `script -f1
 ## Installation
 You can install Swiftline using cocoapods, carthage and Swift package manager
 
-### Cocoapods
+### CocoaPods
     use_frameworks!
     pod 'Swiftline'
 
@@ -289,7 +289,7 @@ Add swiftline as dependency in your `Package.swift`
   )
 ```
 
-### Cocoapods + Rome plugin
+### CocoaPods + Rome plugin
 If you want to use swiftline in a script you can use [Rome](https://github.com/neonichu/Rome) cocoapod plugin. This plugin builds the framework from the pod file and place them in a Rome directory.
 
     platform :osx, '10.10'


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
