### PR TITLE
Fixes broken URL to 'Build Status' in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 <img src="http://swiftline.github.io/img/intro-bg.svg" width="400" align="middle"/>
 <br/>
 </p>
-[![Build Status](https://travis-ci.org/Swiftline/Swiftline.svg?branch=master)](https://travis-ci.org/Swiftline/Swiftline)
+[![Build Status](https://travis-ci.org/oarrabi/Swiftline.svg?branch=master)](https://travis-ci.org/oarrabi/Swiftline)
 [![Platform](https://img.shields.io/badge/platform-osx-lightgrey.svg)](https://travis-ci.org/Swiftline/Swiftline)
 [![Language: Swift](https://img.shields.io/badge/language-swift-orange.svg)](https://travis-ci.org/Swiftline/Swiftline)
 [![CocoaPods](https://img.shields.io/cocoapods/v/Swiftline.svg)](https://cocoapods.org/pods/Swiftline)


### PR DESCRIPTION
### Abstract

Fixes broken URL to 'Travis Build Status' in README

---
#### Before (current)

<img width="757" alt="before" src="https://cloud.githubusercontent.com/assets/4126751/15637091/0b7218d8-264c-11e6-8e03-555df68be466.png">
#### After

<img width="762" alt="after" src="https://cloud.githubusercontent.com/assets/4126751/15637090/09ed8678-264c-11e6-9f3c-0f63a76e43fe.png">
