### PR TITLE
Fix: properly convert `NSString?` to `String?`

### DIFF
--- a/Source/RunResults.swift
+++ b/Source/RunResults.swift
@@ -36,5 +36,5 @@ func splitCommandToArgs(_ command: String) -> [String] {
 
 func readPipe(_ pipe: TaskPipe) -> String {
     let data = pipe.read()
-    return NSString(data: data as Data, encoding: String.Encoding.utf8.rawValue) as? String ?? ""
+    return NSString(data: data as Data, encoding: String.Encoding.utf8.rawValue) as String? ?? ""
 }


### PR DESCRIPTION
This fixes the following warning:

`RunResults.swift:39:82: Conditional downcast from 'NSString?' to 'String' is a bridging conversion; did you mean to use 'as'?`