### PR TITLE
Fix grammar errors

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -65,7 +65,7 @@ Ask, Choose and Agree are used to prompt the user for more information.
 ### Ask
 Ask presents the user with a prompt and waits for the user input.
 ```swift
-let userName = ask("Enter user name?")
+let username = ask("Enter username")
 ```
 `userName` will contain the name entered by the user
 


### PR DESCRIPTION
“Enter user name?”, with a question mark, is a question to which the answer is either “yes” or “no,” not a username. Accordingly, I removed the question mark. (Another possibility would be to simply ask: “What’s your username?”)

Also, the Oxford Dictionary of English gives the compound word “username” to refer to "an identification used by a person with access to a computer, network, or online service,” which I suppose it’s the meaning intended here. I rewrote it like that.